### PR TITLE
Utils did extra work

### DIFF
--- a/accounts/templates/accounts/entries/_entry_list.html
+++ b/accounts/templates/accounts/entries/_entry_list.html
@@ -2,7 +2,7 @@
 <tr data-entry-id="{{ blog_entry.entry_id }}" class="{% for tag in blog_entry.tags %}tag_{{ tag }} {% endfor %}" data-entry-title="{{ blog_entry.title }}">
     <div class="row">
         <div style="word-break: break-all;">
-            <td>[{{ blog_entry.title }}]<a href="{{ blog_entry.url }}" target="_blank">({{ blog_entry.url }})</a></td>
+            <td>[{{ blog_entry.title }}]<a href="{{ blog_entry.clickable }}" target="_blank">({{ blog_entry.url }})</a></td>
         </div>
     </div>
 </tr>

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -26,7 +26,12 @@ def get_user_posts(username, from_id):
         entry_dict = {
             'id': comment.get('id'),
             'title': comment.get('title'),
-            'url': 'https://steemit.com/{0}/@{1}/{2}'.format(
+            'clickable': 'https://www.steemit.com/{0}/@{1}/{2}'.format(
+                category,
+                author,
+                comment.get('permlink'),
+            ),
+            'url': '/{0}/@{1}/{2}'.format(
                 category,
                 author,
                 comment.get('permlink'),

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -21,29 +21,29 @@ def get_user_posts(username, from_id):
         # Could be util to load posts on utopian directly.
         # parent_permlink = comment.get('permlink')
         author = comment.get('author')
-        category = comment.get('category')
-
-        entry_dict = {
-            'id': comment.get('id'),
-            'title': comment.get('title'),
-            'clickable': 'https://www.steemit.com/{0}/@{1}/{2}'.format(
-                category,
-                author,
-                comment.get('permlink'),
-            ),
-            'url': '/{0}/@{1}/{2}'.format(
-                category,
-                author,
-                comment.get('permlink'),
-            ),
-            'author': author,
-            'category': category,
-            'tags': metadata.get('tags'),
-            'images': metadata.get('image'),
-            'entry_id': entry['entry_id']
-        }
 
         if username == author:
+            category = comment.get('category')
+            entry_dict = {
+                'id': comment.get('id'),
+                'title': comment.get('title'),
+                'clickable': 'https://www.steemit.com/{0}/@{1}/{2}'.format(
+                    category,
+                    author,
+                    comment.get('permlink'),
+                ),
+                'url': '/{0}/@{1}/{2}'.format(
+                    category,
+                    author,
+                    comment.get('permlink'),
+                ),
+                'author': author,
+                'category': category,
+                'tags': metadata.get('tags'),
+                'images': metadata.get('image'),
+                'entry_id': entry['entry_id']
+            }
+
             entries_list.append(entry_dict)
 
     return entries_list


### PR DESCRIPTION
Reduced work done by the `get_user_posts` function.

The `get_user_posts` function was creating the dictionary for the entry even if it wasn't by the right author, then it was just not adding the dictionary to the list when the author didn't match.  I changed the order here so that it would check the author first, and then only do the work if it was the author it cared about.
