### PR TITLE
Steem api nodes

### DIFF
--- a/accounts/templates/accounts/entries/_entry_list.html
+++ b/accounts/templates/accounts/entries/_entry_list.html
@@ -2,7 +2,7 @@
 <tr data-entry-id="{{ blog_entry.entry_id }}" class="{% for tag in blog_entry.tags %}tag_{{ tag }} {% endfor %}" data-entry-title="{{ blog_entry.title }}">
     <div class="row">
         <div style="word-break: break-all;">
-            <td>[{{ blog_entry.title }}]<a href="{{ blog_entry.url }}" target="_blank">({{ blog_entry.url }})</a></td>
+            <td>[{{ blog_entry.title }}]<a href="{{ blog_entry.clickable }}" target="_blank">({{ blog_entry.url }})</a></td>
         </div>
     </div>
 </tr>

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -26,7 +26,12 @@ def get_user_posts(username, from_id):
         entry_dict = {
             'id': comment.get('id'),
             'title': comment.get('title'),
-            'url': 'https://steemit.com/{0}/@{1}/{2}'.format(
+            'clickable': 'https://www.steemit.com/{0}/@{1}/{2}'.format(
+                category,
+                author,
+                comment.get('permlink'),
+            ),
+            'url': '/{0}/@{1}/{2}'.format(
                 category,
                 author,
                 comment.get('permlink'),

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,28 +1,29 @@
 import json
 
 from steem import Steem
+from app import settings
 
 
-def get_user_posts(username, from_id):
-    s = Steem()
+def get_user_posts(username, from_id, limit=60):
+    s = Steem(nodes=settings.STEEM_NODES)
 
     blog_entries = s.get_blog(
         account=username,
         entry_id=from_id,
-        limit=60,
+        limit=limit,
     )
 
     entries_list = []
 
     for entry in blog_entries:
         comment = entry['comment']
-        metadata = json.loads(comment.get('json_metadata'))
 
         # Could be util to load posts on utopian directly.
         # parent_permlink = comment.get('permlink')
         author = comment.get('author')
 
         if username == author:
+            metadata = json.loads(comment.get('json_metadata'))
             category = comment.get('category')
             entry_dict = {
                 'id': comment.get('id'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -12,9 +12,9 @@ from django.template.loader import render_to_string
 from .data import SELFIE_CONTEST_PLAYERS
 from .data import PAPAPEPPER_CONTEST_ENTRIES
 from .utils import get_user_posts
+from app import settings
 
 
-s = Steem()
 
 
 class UsernameSearchFormView(View):
@@ -37,6 +37,7 @@ class AccountDetailView(TemplateView):
         if username[0] == '@':
             username = username[1:]
 
+        s = Steem(nodes=settings.STEEM_NODES)
         account_info = s.get_account(username)
         profile_image = None
         name = None
@@ -142,6 +143,7 @@ class ImagesBacklinkViewDetail(TemplateView):
         if username[0] == '@':
             username = username[1:]
 
+        s = Steem(nodes=settings.STEEM_NODES)
         account_info = s.get_account(username)
         profile_image = None
         name = None
@@ -240,7 +242,7 @@ class PepperView(TemplateView):
         if username in SELFIE_CONTEST_PLAYERS:
             registered = True
 
-            s = Steem()
+            s = Steem(nodes=settings.STEEM_NODES)
 
             for entry_dict in PAPAPEPPER_CONTEST_ENTRIES:
                 selfie_dict = {

--- a/app/settings.py
+++ b/app/settings.py
@@ -62,3 +62,14 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+STEEM_NODES = [
+    'https://api.steemit.com',
+    'https://steemd.privex.io',
+    'https://gtg.steem.house:8090',
+    'https://steemd.minnowsupportproject.org',
+    'https://steemd.privex.io',
+    'https://steemd.steemit.com',
+    'https://rpc.steemliberator.com',
+    ]
+

--- a/app/templatetags/general_tags.py
+++ b/app/templatetags/general_tags.py
@@ -2,12 +2,14 @@ from steem import Steem
 
 from django import template
 
+from app import settings
+
 register = template.Library()
 
 
 @register.assignment_tag
 def get_last_ecoinstant_entry():
-    s = Steem()
+    s = Steem(nodes=settings.STEEM_NODES)
     blog_entries = s.get_blog(
         account='ecoinstant',
         entry_id=0,


### PR DESCRIPTION
This should fix the gateway timeout problem.

Mainly it adds a setting called STEEM_NODES to the `app.settings` object that now gets used whenever a `Steem` object needs to be created.

There are other minor changes you can see in the diff (scope of `metadata` in the `get_user_posts`, made `limit` for posts coming back a default parameter so that later a setting could be added to control this).